### PR TITLE
feat: add Claude Code changelog RSS route

### DIFF
--- a/lib/routes/claude-code/changelog.ts
+++ b/lib/routes/claude-code/changelog.ts
@@ -1,0 +1,78 @@
+import { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import MarkdownIt from 'markdown-it';
+
+const md = new MarkdownIt();
+
+export const route: Route = {
+    path: '/changelog',
+    categories: ['program-update'],
+    example: '/claude-code/changelog',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: 'Changelog',
+    maintainers: ['claude'],
+    handler,
+    url: 'https://github.com/anthropics/claude-code',
+    radar: [
+        {
+            source: ['github.com/anthropics/claude-code'],
+        },
+    ],
+};
+
+async function handler() {
+    const changelogUrl = 'https://raw.githubusercontent.com/anthropics/claude-code/refs/heads/main/CHANGELOG.md';
+    
+    const response = await ofetch(changelogUrl);
+    const content = response;
+    
+    // Parse markdown content to extract version entries
+    const versionRegex = /^## \[([^\]]+)\] - (\d{4}-\d{2}-\d{2})/gm;
+    const items = [];
+    
+    const matches = Array.from(content.matchAll(versionRegex));
+    
+    for (let i = 0; i < matches.length; i++) {
+        const match = matches[i];
+        const version = match[1];
+        const dateStr = match[2];
+        const startIndex = match.index!;
+        
+        // Find the end of this version section (start of next version or end of file)
+        const nextMatch = matches[i + 1];
+        const endIndex = nextMatch ? nextMatch.index! : content.length;
+        
+        // Extract content for this version
+        const versionContent = content.substring(startIndex, endIndex).trim();
+        
+        // Convert markdown to HTML for better display
+        const htmlContent = md.render(versionContent);
+        
+        // Create a clean anchor link for the version
+        const anchorId = version.toLowerCase().replace(/[^\w\d]/g, '');
+        
+        items.push({
+            title: `Claude Code ${version}`,
+            description: htmlContent,
+            link: `https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#${anchorId}`,
+            pubDate: parseDate(dateStr),
+            guid: `claude-code-${version}`,
+        });
+    }
+    
+    return {
+        title: 'Claude Code Changelog',
+        link: 'https://github.com/anthropics/claude-code',
+        description: 'Latest changes and updates to Claude Code',
+        item: items.slice(0, 20), // Limit to last 20 releases
+    };
+}

--- a/lib/routes/claude-code/namespace.ts
+++ b/lib/routes/claude-code/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Claude Code',
+    url: 'claude.ai/code',
+    description: 'The official CLI for Claude',
+    lang: 'en',
+};


### PR DESCRIPTION
Add RSS route for Claude Code changelog at /claude-code/changelog
- Fetches CHANGELOG.md from GitHub repository
- Parses markdown version entries with dates
- Converts to RSS format with HTML descriptions
- Supports up to 20 latest releases

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
